### PR TITLE
Use bintray for v0.9.3 ddev_osx

### DIFF
--- a/Formula/ddev.rb
+++ b/Formula/ddev.rb
@@ -1,7 +1,7 @@
 class Ddev < Formula
   desc "ddev: a local development environment management system"
   homepage "https://ddev.readthedocs.io/en/latest/"
-  url "https://github.com/drud/ddev/releases/download/v0.9.3/ddev_osx.v0.9.3.tar.gz"
+  url "https://drud.bintray.com/ddev/v0.9.3/ddev_osx.v0.9.3.tar.gz"
   sha256 "2cbbe0048c072833e5adb505f62cd4387a76bfc20997c1e581745a887e7f6023"
 
   # Dependencies don't currently seem to be useful since brew doesn't have edge and people likely will not have


### PR DESCRIPTION
We want to use bintray for the v0.9.3 ddev_osx tarball