### PR TITLE
Add caveat about the docker requirement, fixes drud/ddev#597

### DIFF
--- a/Formula/ddev.rb
+++ b/Formula/ddev.rb
@@ -10,9 +10,17 @@ class Ddev < Formula
   # depends_on "docker-compose" => :run
 
   def install
-  	system "mkdir", "-p", "#{bin}"
-  	system "cp", "ddev", "#{bin}/ddev"
-	bash_completion.install "ddev_bash_completion.sh" => "ddev"
+    system "mkdir", "-p", "#{bin}"
+    system "cp", "ddev", "#{bin}/ddev"
+    bash_completion.install "ddev_bash_completion.sh" => "ddev"
+  end
+
+  def caveats
+  <<~EOS
+ddev requires docker and docker-compose.
+You can install them with "brew cask install docker"
+or from the docker.com website.
+  EOS
   end
 
   test do


### PR DESCRIPTION
In drud/ddev#597 @budda pointed out that our homebrew recipe doesn't mention to people that docker is required. This goes a bit farther. It's a little complicated to actually formally *require* docker because docker may be installed a number of ways. Maybe @cweagans knows the right way though!