### PR TITLE
Linux homebrew-ddev for v1.5.1, bottles, and source build capability

### DIFF
--- a/Formula/ddev.rb
+++ b/Formula/ddev.rb
@@ -12,8 +12,13 @@ class Ddev < Formula
   def install
     system "make", "VERSION=v#{version}", "COMMIT=v#{version}"
     system "mkdir", "-p", "#{bin}"
-    system "cp", "bin/darwin/darwin_amd64/ddev", "#{bin}/ddev"
-    system "bin/darwin/darwin_amd64/ddev_gen_autocomplete"
+    if OS.mac?
+      system "cp", "bin/darwin/darwin_amd64/ddev", "#{bin}/ddev"
+      system "bin/darwin/darwin_amd64/ddev_gen_autocomplete"
+    else
+      system "cp", "bin/linux/ddev", "#{bin}/ddev"
+      system "bin/linux/ddev_gen_autocomplete"
+    end
     bash_completion.install "bin/ddev_bash_completion.sh" => "ddev"
   end
 

--- a/Formula/ddev.rb
+++ b/Formula/ddev.rb
@@ -9,6 +9,13 @@ class Ddev < Formula
   depends_on "docker" => :build
   depends_on "go" => :build
 
+  bottle do
+    root_url "https://dl.bintray.com/drud/bottles-ddev"
+    cellar :any_skip_relocation
+    sha256 "16316d98bcad17ba0b53f37bab2b134835f6a6d334ec1485e43cf620ae9a8cf5" => :x86_64_linux
+    sha256 "d1139d57fb8ea0f3c75563caf81ab091e5ba096008b107f1fa15465a067c51ce" => :el_capitan
+  end
+
   def install
     system "make", "VERSION=v#{version}", "COMMIT=v#{version}"
     system "mkdir", "-p", "#{bin}"

--- a/Formula/ddev.rb
+++ b/Formula/ddev.rb
@@ -29,8 +29,7 @@ class Ddev < Formula
   def caveats
   <<~EOS
 ddev requires docker and docker-compose.
-You can install them with "brew cask install docker"
-or from the docker.com website.
+Docker installation instructions at https://ddev.readthedocs.io/en/latest/users/docker_installation/
   EOS
   end
 

--- a/Formula/ddev.rb
+++ b/Formula/ddev.rb
@@ -10,7 +10,7 @@ class Ddev < Formula
   depends_on "go" => :build
 
   def install
-    system "make"
+    system "make", "VERSION=v#{version}", "COMMIT=v#{version}"
     system "mkdir", "-p", "#{bin}"
     system "cp", "bin/darwin/darwin_amd64/ddev", "#{bin}/ddev"
     system "bin/darwin/darwin_amd64/ddev_gen_autocomplete"
@@ -29,9 +29,6 @@ or from the docker.com website.
   EOS
   end
 
-  test do
-    system "#{bin}/ddev", "version"
-  end
 end
 
 

--- a/Formula/ddev.rb
+++ b/Formula/ddev.rb
@@ -1,18 +1,24 @@
 class Ddev < Formula
   desc "ddev: a local development environment management system"
   homepage "https://ddev.readthedocs.io/en/stable/"
-  url "https://github.com/drud/ddev/releases/download/v1.5.1/ddev_macos.v1.5.1.tar.gz"
-  sha256 "b21438b90697f947dfed8c462edc67738eea160443a2ba696e8d87ea8038c6ac"
+  url "https://github.com/drud/ddev/archive/v1.5.1.tar.gz"
+  sha256 "6df1e15bb44774665bee028ac5c9d11a8babb9646707afd71177566af68581fb"
 
-  # Dependencies don't currently seem to be useful since people likely will not have
-  # used brew to install docker.
   # depends_on "docker" => :run
   # depends_on "docker-compose" => :run
+  depends_on "docker" => :build
+  depends_on "go" => :build
 
   def install
+    system "make"
     system "mkdir", "-p", "#{bin}"
-    system "cp", "ddev", "#{bin}/ddev"
-    bash_completion.install "ddev_bash_completion.sh" => "ddev"
+    system "cp", "bin/darwin/darwin_amd64/ddev", "#{bin}/ddev"
+    system "bin/darwin/darwin_amd64/ddev_gen_autocomplete"
+    bash_completion.install "bin/ddev_bash_completion.sh" => "ddev"
+  end
+
+  test do
+    system "#{bin}/ddev", "version"
   end
 
   def caveats

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# drud/ddev Homebrew and Linuxbrew Formulas
+
+This formula can build the ddev package from source or pull from bottles.
+
+Updating:
+
+* Add the url and sha256 of the new release source-code tarball to the homebrew-ddev local version.
+* Create new bottles on linux and macOS (before pushing new formula:
+```
+   brew uninstall ddev
+   cd homebrew-ddev  # directory with new source tarball/hash
+   brew install --build-bottle Formulas/ddev.rb`
+   brew bottle ddev
+```
+* Add the bottles into the formula per the output of `brew bottle`. 
+* Create the new version number on bintray.com (drud org, ddev project)
+* Push the new bottles; note that the name changes from high_sierra to el_capitan with the macOS version, and that the "--" changes to "-" inexplicably: 
+  `curl -T ddev--<version>.x86_64_linux.bottle.tar.gz -urfay:b5e3b1b50e3ef9255140f5fd444d1e4029ece4da https://api.bintray.com/content/drud/bottles-ddev/ddev/v<version>/ddev-<version>.x86_64_linux.bottle.tar.gz`
+  `curl -T ddev--1.5.1.high_sierra.bottle.tar.gz -urfay:b5e3b1b50e3ef9255140f5fd444d1e4029ece4da https://api.bintray.com/content/drud/bottles-ddev/ddev/v1.5.1/ddev-1.5.1.el_capitan.bottle.tar.gz`
+* Publish the files on bintray.com.
+* Create the PR for the new homebrew version.
+
+I'm quite sure we'll automate most of this, but this is the documented process at this time.
+
+You should be able to build from source any time using `brew reinstall --build-from-source ddev`


### PR DESCRIPTION
This PR adds the 
* ability to build from source (`brew install --build-from-source ddev`) 
* build bottles (see readme)
* Download from bottles on dl.bintray.com
* LINUX support for [Linuxbrew](https://linuxbrew.sh/)!

Manual testing before pull:
* brew uninstall --force ddev
* brew tap rfay/ddev
* brew install ddev (on both linux and macOS)
* brew install --build-from-source (on both linux and macOS)
* Verify correct behavior of ddev binary.
* Review README.md