### PR TITLE
Bump to v1.5.2

### DIFF
--- a/Formula/ddev.rb
+++ b/Formula/ddev.rb
@@ -1,8 +1,8 @@
 class Ddev < Formula
   desc "ddev: a local development environment management system"
   homepage "https://ddev.readthedocs.io/en/stable/"
-  url "https://github.com/drud/ddev/archive/v1.5.1.tar.gz"
-  sha256 "6df1e15bb44774665bee028ac5c9d11a8babb9646707afd71177566af68581fb"
+  url "https://github.com/drud/ddev/archive/v1.5.2.tar.gz"
+  sha256 "88add1c437153df8a7160f71b988bfaa580261b6e6fa1b7cf28da4b9d647ce62"
 
   # depends_on "docker" => :run
   # depends_on "docker-compose" => :run
@@ -20,13 +20,13 @@ class Ddev < Formula
     system "make", "VERSION=v#{version}", "COMMIT=v#{version}"
     system "mkdir", "-p", "#{bin}"
     if OS.mac?
-      system "cp", "bin/darwin/darwin_amd64/ddev", "#{bin}/ddev"
-      system "bin/darwin/darwin_amd64/ddev_gen_autocomplete"
+      system "cp", ".gotmp/bin/darwin_amd64/ddev", "#{bin}/ddev"
+      system ".gotmp/bin/darwin_amd64/ddev_gen_autocomplete"
     else
-      system "cp", "bin/linux/ddev", "#{bin}/ddev"
-      system "bin/linux/ddev_gen_autocomplete"
+      system "cp", ".gotmp/bin/ddev", "#{bin}/ddev"
+      system ".gotmp/bin/ddev_gen_autocomplete"
     end
-    bash_completion.install "bin/ddev_bash_completion.sh" => "ddev"
+    bash_completion.install ".gotmp/bin/ddev_bash_completion.sh" => "ddev"
   end
 
   test do

--- a/Formula/ddev.rb
+++ b/Formula/ddev.rb
@@ -12,8 +12,8 @@ class Ddev < Formula
   bottle do
     root_url "https://dl.bintray.com/drud/bottles-ddev"
     cellar :any_skip_relocation
-    sha256 "16316d98bcad17ba0b53f37bab2b134835f6a6d334ec1485e43cf620ae9a8cf5" => :x86_64_linux
-    sha256 "d1139d57fb8ea0f3c75563caf81ab091e5ba096008b107f1fa15465a067c51ce" => :el_capitan
+    sha256 "1ca62f7dfb8190f36349ebe83ef7e36849c4bb4ec4156b5a0cd63ef93173c11f" => :x86_64_linux
+    sha256 "6658216efaa45f2397a9a8d6313e5b526135c648754bcb6563eab898dbe151fa" => :el_capitan
   end
 
   def install


### PR DESCRIPTION
* Reorganize the build to use the new .gotmp/bin location for binaries
* Update with new bottles for Linux and macOS in bintray.

The bottle creation absolutely has to be automated!