### PR TITLE
Add mkcert as a dependencyfor drud/ddev#1540

### DIFF
--- a/Formula/ddev.rb
+++ b/Formula/ddev.rb
@@ -8,6 +8,7 @@ class Ddev < Formula
   # depends_on "docker-compose" => :run
   depends_on "docker" => :build
   depends_on "go" => :build
+  depends_on "mkcert" => :run
 
   bottle do
     root_url "https://github.com/drud/ddev/releases/download/v1.7.1/"
@@ -19,6 +20,7 @@ class Ddev < Formula
   def install
     system "make", "VERSION=v#{version}", "COMMIT=v#{version}"
     system "mkdir", "-p", "#{bin}"
+    system "mkcert", "-install"
     if OS.mac?
       system "cp", ".gotmp/bin/darwin_amd64/ddev", "#{bin}/ddev"
       system ".gotmp/bin/darwin_amd64/ddev_gen_autocomplete"
@@ -36,7 +38,7 @@ class Ddev < Formula
   def caveats
   <<~EOS
 ddev requires docker and docker-compose.
-Docker installation instructions at https://ddev.readthedocs.io/en/latest/users/docker_installation/
+Docker installation instructions at https://ddev.readthedocs.io/en/stable/users/docker_installation/
   EOS
   end
 

--- a/Formula/ddev.rb
+++ b/Formula/ddev.rb
@@ -20,7 +20,6 @@ class Ddev < Formula
   def install
     system "make", "VERSION=v#{version}", "COMMIT=v#{version}"
     system "mkdir", "-p", "#{bin}"
-    system "mkcert", "-install"
     if OS.mac?
       system "cp", ".gotmp/bin/darwin_amd64/ddev", "#{bin}/ddev"
       system ".gotmp/bin/darwin_amd64/ddev_gen_autocomplete"
@@ -37,6 +36,8 @@ class Ddev < Formula
 
   def caveats
   <<~EOS
+PLEASE MAKE SURE to do `mkcert -install`, which may require your sudo password.
+
 ddev requires docker and docker-compose.
 Docker installation instructions at https://ddev.readthedocs.io/en/stable/users/docker_installation/
   EOS

--- a/Formula/ddev.rb
+++ b/Formula/ddev.rb
@@ -9,6 +9,7 @@ class Ddev < Formula
   depends_on "docker" => :build
   depends_on "go" => :build
   depends_on "mkcert" => :run
+  depends_on "nss" => :run
 
   bottle do
     root_url "https://github.com/drud/ddev/releases/download/v1.7.1/"


### PR DESCRIPTION
drud/ddev#1540 introduces use of mkcert; this makes mkcert a dependency and does the mkcert -install.

The key question about this PR is that `mkcert -install` on most systems will require a sudo password. Will people understand that?