### PR TITLE
fix: update instructions for old formula, for ddev/ddev#7297, fixes #52

### DIFF
--- a/Formula/ddev.rb
+++ b/Formula/ddev.rb
@@ -123,8 +123,8 @@ class Ddev < Formula
         ERROR: your homebrew tap is the ancient #{tap.full_name},
         but that repository has moved.
         Please run:
+          rm -rf "$(brew --repo #{tap.full_name})"
           brew uninstall -f ddev
-          brew untap #{tap.full_name}
           brew install ddev/ddev/ddev
       EOS
     end

--- a/Formula/ddev.rb
+++ b/Formula/ddev.rb
@@ -118,7 +118,7 @@ class Ddev < Formula
   # fail fast if tapped under the old drud or rfay names
   def initialize(*args, **kwargs)
     super(*args, **kwargs)
-    if ["drud/homebrew-ddev", "rfay/homebrew-ddev"].include?(tap.full_name)
+    if ["drud/homebrew-ddev", "rfay/homebrew-ddev"].include?(tap&.full_name)
       odie <<~EOS
         ERROR: your homebrew tap is the ancient #{tap.full_name},
         but that repository has moved.


### PR DESCRIPTION
## The Issue

- ddev/ddev#7297

## How This PR Solves The Issue

`initialize` doesn't seem to know about `uninstall`. And moving the check to `install` didn't help.

We can remove the formula before removing the `ddev` binary.

## Manual Testing Instructions

```
brew install drud/ddev/ddev
cd "$(brew --repo drud/homebrew-ddev)"
git reset --hard HEAD~1
brew install drud/ddev/ddev
cd ~
brew update
brew uninstall -f ddev
# old, not updated error here

rm -rf "$(brew --repo drud/homebrew-ddev)"
brew uninstall -f ddev
brew install ddev/ddev/ddev
```

The same but using `ddev-test` repo to see the updated error message:

```
brew install ddev-test/ddev-edge/ddev
cd "$(brew --repo ddev-test/homebrew-ddev-edge)"

# install old version version without the check for old formula
brew install ddev-test/ddev-edge/ddev
git checkout c1d0f9b725a50ddd58043ca3b7d4f01d9b61aecf
$ ddev -v
ddev version v1.23.31

cd ~
brew update

$ brew uninstall -f ddev
Error: ERROR: your homebrew tap is the ancient ddev-test/homebrew-ddev-edge,
but that repository has moved.
Please run:
  rm -rf "$(brew --repo ddev-test/homebrew-ddev-edge)"
  brew uninstall -f ddev
  brew install ddev/ddev-edge/ddev

rm -rf "$(brew --repo ddev-test/homebrew-ddev-edge)"
brew uninstall -f ddev
# should succeed
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

